### PR TITLE
Fix shebang

### DIFF
--- a/fffffx/python-eval/main.py
+++ b/fffffx/python-eval/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 K = int(input())
 S = '(' + input().replace('^', '**') + ')%998'

--- a/fffffx/tests/validator.py
+++ b/fffffx/tests/validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/lcm-and-gcd/tests/validator.py
+++ b/lcm-and-gcd/tests/validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/straight-conditions/tests/validator.py
+++ b/straight-conditions/tests/validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/unions/tests/validator.py
+++ b/unions/tests/validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/x-word-database/tests/validator.py
+++ b/x-word-database/tests/validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys


### PR DESCRIPTION
`#!/usr/bin/python3` より `#!/usr/bin/env python3` の方が良いらしい