### PR TITLE
Range Rotate Query: Fix TL

### DIFF
--- a/range-rotate-query/PROBLEM
+++ b/range-rotate-query/PROBLEM
@@ -3,7 +3,7 @@
 pid='X'
 
 problem(
-  time_limit=1.0,
+  time_limit=1.5,
   id=pid,
   title=pid + "Range Rotate Query",
   #wiki_name="Your pukiwiki page name", # for wikify plugin


### PR DESCRIPTION
PyPyで300ms程度で通ることを確認した。
Rimeのテストが落ちるとmergeできず困るので、Rime上でのTLを緩和する。